### PR TITLE
Add images to posts

### DIFF
--- a/_posts/2013-10-8-meetup.html
+++ b/_posts/2013-10-8-meetup.html
@@ -10,7 +10,7 @@
 <ul class="talks">
 
   <li>
-    <h4><span>Rebecca Conrad & Lisa Passing:</span> Rails Girls SoC - All for one and one for all</h4>
+    <img src="https://si0.twimg.com/profile_images/1506394191/railsgirls-heart.png"><h4><span>Rebecca Conrad & Lisa Passing:</span> Rails Girls SoC - All for one and one for all</h4>
     <p>
       Rails Girls Summer of Code is a global event which focuses on bringing more women into the world of open source software and helping participants to further expand their knowledge and skills in programming. 33 students got the chance to work paid and full-time on their projects, attend tech conferences and even speak on them. This all wouldn´t haven been possible without a great team of volunteers, organizers and sponsors. Lisa (implementing the webdesign) and Rebecca (adding illustrations) will talk a little more about the organisation and their involvement. 
     </p>
@@ -26,9 +26,10 @@
   </li>
   
   <li>
-    <h4><span>Francesco Kirchhoff:</span> On empathy and communication in project teams/with clients</h4>
+    <img src="https://si0.twimg.com/profile_images/228419888/kopf.jpg"><h4><span>Francesco Kirchhoff:</span> “That’s not what I meant”: On empathy in our work</h4>
     <p>
-      tba
+      Besides the skills specific to our job, a huge part of building digital products is about communicating with other people. The better we understand our clients’, bosses’ and colleagues’, and the better we are at helping them understand us and what we do, the better the project will turn out and the less stress we are likely to generate.
+      Some general thoughts on a more empathetic approach to communication and a list of specific ideas to improve understanding and avoid communication breakdowns.
     </p>
 
     <p class="speaker_info">
@@ -41,7 +42,7 @@
   </li>
 
   <li>
-    <h4><span>Behrad Mirafshar:</span> Design habits</h4>
+    <img src="https://si0.twimg.com/profile_images/378800000137160636/7632c26862c67bea73b903b08edc6ab7.jpeg"><h4><span>Behrad Mirafshar:</span> Design habits</h4>
     <p>
       Our digital life is bombarded by apps. However, we use few of them on a daily basis. This does
       not mean that the other apps are not well­designed, this is basically because they are unable to


### PR DESCRIPTION
This is my idea for images in talks; we just take the user profile pictures and put them next to the title.
![screen shot 2013-10-04 at 12 17 25 pm](https://f.cloud.github.com/assets/358992/1268456/9d459c08-2cdf-11e3-9b4f-4b202663410a.png)

However I'm not sure about the implementation (you can't see the CSS here as I already commited it to gh-pages in 2b9139fbbd97552d74a0dba3e7b54653305165df). Here is the CSS-Code:

``` css
img{
  float: left;
  border-radius: 25px;
  margin-left: -65px;
  width: 50px;
  height: 50px;
}
```

So I'm basically giving the image a negative margin to put it on the left.
