### PR TITLE
Fixing a typo I came across on the up.front.ug site

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -161,7 +161,7 @@
         <h3>Code of Conduct</h3>
 
         <p>
-          If you are attending, organizing or speaking at our event, you are required to agree with our <a href="codeofconduct.html">Code of Conduct</a>. If you encounter or observe any behaviour that is not in line wiht the Code of Conduct, please contact one of our team members by talking to us directly or tweeting to us at <a href="https://twitter.com/upfront_ug">@upfront_ug</a> or at our personal twitter accounts. – <a href="http://twitter.com/Qate_Oh">Katha</a>, <a href="http://twitter.com/espylaub" title="Alex Feyerke on Twitter">Alex</a>, <a href="http://twitter.com/maxfell">Max</a>, <a href="http://twitter.com/kriesse" title="Kristina Schneider on Twitter">Kristina</a>.
+          If you are attending, organizing or speaking at our event, you are required to agree with our <a href="codeofconduct.html">Code of Conduct</a>. If you encounter or observe any behaviour that is not in line with the Code of Conduct, please contact one of our team members by talking to us directly or tweeting to us at <a href="https://twitter.com/upfront_ug">@upfront_ug</a> or at our personal twitter accounts. – <a href="http://twitter.com/Qate_Oh">Katha</a>, <a href="http://twitter.com/espylaub" title="Alex Feyerke on Twitter">Alex</a>, <a href="http://twitter.com/maxfell">Max</a>, <a href="http://twitter.com/kriesse" title="Kristina Schneider on Twitter">Kristina</a>.
         </p>
 
 


### PR DESCRIPTION
The diff doesn't show this too well, but this is simply a change to fix a typo in the footer on the site, from:

> not in line **wiht** the Code of Conduct

to:

> not in line **with** the Code of Conduct

Thanks!
